### PR TITLE
created util method hasAnyRole()

### DIFF
--- a/src/Helpers/RoleManager.php
+++ b/src/Helpers/RoleManager.php
@@ -18,6 +18,23 @@ class RoleManager
     }
 
     /**
+     * Check if the authenticated user has any of the given roles, and if so, execute and return the callback.
+     * 
+     * @param array $roles
+     * @param callable $callback
+     * @return bool
+     */
+    public static function hasAnyRole(array $roles)
+    {
+        foreach ($roles as $role) {
+            if (self::hasRole($role)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Get all roles of authenticated user.
      * If guest, an empty array will be returned.
      *

--- a/tests/Helpers/RoleManagerTest.php
+++ b/tests/Helpers/RoleManagerTest.php
@@ -28,3 +28,16 @@ test('::hasRole() with a logged in user', function () {
     expect(RoleManager::hasRole('user'))->toBeTrue();
     expect(RoleManager::hasRole('foobar'))->toBeFalse();
 });
+
+test('::onTheseRoles() false when not logged in', function () {
+    expect(RoleManager::onTheseRoles(['user'], fn() => true))->toBeNull();
+});
+
+test('::onTheseRoles() with a logged in user', function () {
+    Auth::guard('fusionauth')->setUser(
+        new FusionAuthJwtUser(['roles' => ['user', 'admin']])
+    );
+
+    expect(RoleManager::onTheseRoles(['user'], fn() => true))->toBeTrue();
+    expect(RoleManager::onTheseRoles(['foobar'], fn() => true))->toBeNull();
+});


### PR DESCRIPTION
The hasRole function is useful but checking for multiple roles is annoying, so I made a method for the library that check on has roles and then apply a callable if is on the roles given:

using this method make the use more elegant:
```php
 RoleManager::onTheseRoles(
    ['foo', 'bar', 'baz'],
    fn() => doSomething()
);
```

## EDIT
After some reflection this solution was reached:
- Removed the callback so it can be used as an extension of `hasRole`
```php
 RoleManager:: hasAnyRole(['foo', 'bar', 'baz']);
```